### PR TITLE
keyhandler: use DISMISS_KEYGUARD_SECURELY_ACTION to open camera

### DIFF
--- a/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
+++ b/keyhandler/src/com/cyanogenmod/settings/device/KeyHandler.java
@@ -48,6 +48,9 @@ public class KeyHandler implements DeviceKeyHandler {
     private static final String TAG = KeyHandler.class.getSimpleName();
     private static final int GESTURE_REQUEST = 1;
 
+    private static final String ACTION_DISMISS_KEYGUARD =
+            "com.android.keyguard.action.DISMISS_KEYGUARD_SECURELY";
+
     // Supported scancodes
     private static final int FLIP_CAMERA_SCANCODE = 249;
     private static final int GESTURE_CIRCLE_SCANCODE = 250;
@@ -120,11 +123,8 @@ public class KeyHandler implements DeviceKeyHandler {
                 if (mKeyguardManager.isKeyguardSecure() && mKeyguardManager.isKeyguardLocked()) {
                     action = MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA_SECURE;
                 } else {
-                    try {
-                        WindowManagerGlobal.getWindowManagerService().dismissKeyguard();
-                    } catch (RemoteException e) {
-                        // Ignore
-                    }
+                    mContext.sendBroadcastAsUser(new Intent(ACTION_DISMISS_KEYGUARD),
+                            UserHandle.CURRENT);
                     action = MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA;
                 }
                 mPowerManager.wakeUp(SystemClock.uptimeMillis());


### PR DESCRIPTION
Using the window manager to dismiss the keyguard requires the screen to
be already turned on. Since we're going from an off state, use
DISMISS_KEYGUARD_SECURELY_ACTION to handle the logic.

Change-Id: I427f12fce2344c2ce930210bb14a8fa905239228
Signed-off-by: Roman Birg <roman@cyngn.com>