### PR TITLE
configpanel: reenable TouchScreenGestureSettings if required

### DIFF
--- a/configpanel/src/com/cyanogenmod/settings/device/Startup.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/Startup.java
@@ -52,6 +52,7 @@ public class Startup extends BroadcastReceiver {
             if (!hasTouchscreenGestures()) {
                 disableComponent(context, TouchscreenGestureSettings.class.getName());
             } else {
+                enableComponent(context, TouchscreenGestureSettings.class.getName());
                 // Restore nodes to saved preference values
                 for (String pref : Constants.sNodePreferenceMap.keySet()) {
                     boolean defaultValue = Constants.sNodeDefaultMap.get(pref).booleanValue();
@@ -149,6 +150,17 @@ public class Startup extends BroadcastReceiver {
         pm.setComponentEnabledSetting(name,
                 PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
                 PackageManager.DONT_KILL_APP);
+    }
+
+    private void enableComponent(Context context, String component) {
+        ComponentName name = new ComponentName(context, component);
+        PackageManager pm = context.getPackageManager();
+        if (pm.getComponentEnabledSetting(name)
+                == PackageManager.COMPONENT_ENABLED_STATE_DISABLED) {
+            pm.setComponentEnabledSetting(name,
+                    PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                    PackageManager.DONT_KILL_APP);
+        }
     }
 
     private static boolean hasOClick() {


### PR DESCRIPTION
This may have been disabled for some users becuase of sepolicy issues -
reenable it on boot if we can.

Change-Id: I343825d08b150dd46a11806102ef93a33bcde745
Signed-off-by: Roman Birg <roman@cyngn.com>